### PR TITLE
Add TODO outlines for modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to Voidbound
+
+Thank you for your interest in helping build **Voidbound**! This project is in an early planning phase. Contributions are welcome as we flesh out the core mechanics and world.
+
+## Roadmap
+
+1. **Core Systems**
+   - Flesh out `Player`, `Enemy`, and `Zone` classes.
+   - Create simple combat interactions and health management.
+2. **World Generation**
+   - Implement zone connections and basic exploration logic.
+   - Populate zones with randomized events and enemies.
+3. **Narrative & Lore**
+   - Expand introductory text and NPC dialogue.
+   - Add item descriptions and world-building notes.
+4. **User Interface**
+   - Start with a simple text interface.
+   - Plan for potential graphical front end in the future.
+
+Pull requests that tackle any of these milestones are greatly appreciated. Feel free to open issues with ideas or suggestions.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ MIT License — free to use, modify, and build upon.
 ## 💡 Contributing
 
 Pull requests and ideas welcome! This is an experimental solo project with an emphasis on creativity, simplicity, and story-driven design.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the current development roadmap and ways to get involved.
 
 ---
 

--- a/voidbound/__init__.py
+++ b/voidbound/__init__.py
@@ -1,0 +1,4 @@
+"""Voidbound game package.
+
+TODO: Initialize package-level variables or helper functions here.
+"""

--- a/voidbound/enemies.py
+++ b/voidbound/enemies.py
@@ -1,0 +1,11 @@
+"""Enemy definitions and behavior."""
+
+# TODO: Create base Enemy class with common stats and actions.
+# TODO: Define specific enemy types (e.g., Undead, Beast) inheriting from Enemy.
+
+class Enemy:
+    """Basic enemy prototype."""
+
+    def __init__(self, name: str, health: int) -> None:
+        self.name = name
+        self.health = health

--- a/voidbound/lore.py
+++ b/voidbound/lore.py
@@ -1,0 +1,8 @@
+"""Game narrative, dialogues, and descriptions."""
+
+# TODO: Store introductory text, NPC conversations, and item lore.
+# TODO: Provide helper functions to fetch random bits of lore.
+
+LORE_INTRO = """\
+You awaken in darkness. Again. The stones drip with memories long forgotten...
+"""

--- a/voidbound/main.py
+++ b/voidbound/main.py
@@ -1,0 +1,15 @@
+"""Game entry point.
+
+TODO:
+- Initialize game state and start main loop.
+- Handle player input and high-level game flow.
+"""
+
+
+def main() -> None:
+    """Start the Voidbound game."""
+    pass  # Game loop will be implemented here
+
+
+if __name__ == "__main__":
+    main()

--- a/voidbound/player.py
+++ b/voidbound/player.py
@@ -1,0 +1,13 @@
+"""Player stats, combat routines, and inventory management."""
+
+# TODO: Define Player class with health, stats, abilities, and items.
+# TODO: Implement methods for combat actions, leveling, and equipment.
+
+class Player:
+    """Represents the main player character."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        # Basic stats placeholders
+        self.health = 100
+        self.inventory = []

--- a/voidbound/utils.py
+++ b/voidbound/utils.py
@@ -1,0 +1,10 @@
+"""Helper functions and common utilities."""
+
+# TODO: Add text formatting helpers, dice rolls, and other utility functions.
+
+
+def roll_die(sides: int) -> int:
+    """Return a random number between 1 and the number of sides."""
+    import random
+
+    return random.randint(1, sides)

--- a/voidbound/world.py
+++ b/voidbound/world.py
@@ -1,0 +1,11 @@
+"""Procedural generation of zones and world events."""
+
+# TODO: Implement Zone class representing areas the player can explore.
+# TODO: Create methods for random event generation and zone connections.
+
+class Zone:
+    """Placeholder for zone representation."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        # Additional attributes such as enemies, items, and exits will be added


### PR DESCRIPTION
## Summary
- set up package skeleton with TODO sections for game modules
- add roadmap to CONTRIBUTING doc and crosslink from README

## Testing
- `python -m py_compile voidbound/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6843608ca1dc8322b086e7a3ea4e01cd